### PR TITLE
Handle FILE_TOO_LARGE error

### DIFF
--- a/specials/SF_UploadWindow.php
+++ b/specials/SF_UploadWindow.php
@@ -542,6 +542,9 @@ END;
 				$error = $details['error'];
 				$this->uploadError( wfMessage( $error )->parse() );
 				break;
+			case UploadBase::FILE_TOO_LARGE:
+				$this->showUploadForm( $this->getUploadForm( wfMessage( 'file-too-large' )->escaped() ) );
+				break;
 			default:
 				throw new MWException( __METHOD__ . ": Unknown value `{$details['status']}`" );
 		}


### PR DESCRIPTION
Show a graceful error message when uploading a large image on a condition report. Closes https://github.com/RopeWiki/app/issues/56

I briefly tested this locally.